### PR TITLE
Hide blocking tutorial message on first tap

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,14 +243,8 @@ document.getElementById("iapBtn").onclick=()=>showToast("준비중");
 setInterval(save,10000);
 
 // 튜토리얼
-const tut=["화면 중앙을 탭하면 요리가 준비돼요!","업그레이드 탭에서 재료 공급을 올려보세요.","설비/직원 탭에서 요리사를 고용하세요.","앱을 닫아도 돌아오면 오프라인 수익을 받아요!"];
-let tutStep=0;
-function nextTut(){
- if(tutStep<tut.length){tutorialEl.textContent=tut[tutStep]+" (터치)";}else{tutorialEl.style.display="none";}
- tutStep++;
-}
-tutorialEl.addEventListener("click",nextTut);
-nextTut();
+tutorialEl.textContent="화면 중앙을 탭하면 요리가 준비돼요! (터치)";
+tutorialEl.addEventListener("pointerdown",()=>{tutorialEl.style.display="none";});
 
 // 초기 실행
 load();


### PR DESCRIPTION
## Summary
- Dismiss tutorial overlay on first tap to allow scrolling and interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950cf0285883328f789f85b0887ec2